### PR TITLE
Add custom built-in action messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 /node_modules
 config.js
 /.vscode
+
 /commands/test.js
+
 /contextCommands/test.js
+
 /slashCommands/test.js
+
 /jsonFiles-AprilFools
+/jsonFiles/authorSpecificMessages.json

--- a/commands/clearmsgs.js
+++ b/commands/clearmsgs.js
@@ -1,0 +1,73 @@
+const Discord = require('discord.js');
+const fs = require('fs');
+const { client } = require('../constants.js');
+
+
+module.exports = {
+    name: 'clearmsgs',
+    description: `Clears all custom built-in Action Messages for a specific User`,
+    
+    // Cooldown is in seconds
+    cooldown: 10,
+
+    // Limitation
+    //    - "dev" for TwilightZebby only
+    //    - "owner" for Server Owners and TwilightZebby
+    //    - Comment out for everyone
+    limitation: "dev",
+
+    // Uncomment for making the command only usable in DMs with the Bot
+    //    - DO NOT have both this AND "guildOnly" uncommented, only one or neither
+    //dmOnly: true,
+
+    // Uncomment for making the command only usable in Servers
+    //   - DO NOT have both this AND "dmOnly" uncommented, only one or neither
+    guildOnly: true,
+
+    // Required Arguments?
+    //   - Does the command require arguments? (at least one) Comment out if works without arguments
+    requiresArgs: true,
+    
+    // Argument Checks
+    //   - Minimum required arguments, only use if "requiresArgs" is uncommented
+    //minimumArgs: 2,
+    //   - Maximum required arguments, can be used regardless of if "requiresArgs" is commented out or not
+    //maximumArgs: 5,
+
+
+    /**
+     * Entry point that runs the command
+     * 
+     * @param {Discord.Message} message Origin message that triggered this command
+     * @param {Array<String>} args The given arguments of the command. Be sure to check for no arguments!
+     */
+    async execute(message, args) {
+
+        let AUTHORMESSAGES = require('../jsonFiles/authorSpecificMessages.json');
+
+        // Fetch argument
+        let targetUserID = args.shift();
+
+        if ( !AUTHORMESSAGES[`${targetUserID}`] )
+        {
+            // User doesn't have preset custom messages, thus return
+            return await message.reply({ content: `Sorry, but the User \<\@${targetUserID}\> doesn't have any stored custom messages, thus I cannot clear them.`, allowedMentions: { parse: [], repliedUser: false } });
+        }
+        else
+        {
+            // User does have preset custom messages already, so clear them
+            delete AUTHORMESSAGES[`${targetUserID}`];
+
+            // Write to JSON
+            fs.writeFile('./jsonFiles/authorSpecificMessages.json', JSON.stringify(AUTHORMESSAGES, null, 4), async (err) => {
+                if (err)
+                {
+                    return await message.reply({ content: `Sorry, but an error occurred while trying to clear stored custom messages for User \<\@${targetUserID}\>...`, allowedMentions: { parse: [], repliedUser: false } });
+                }
+            });
+
+            return await message.reply({ content: `Successfully cleared all stored custom messages for User \<\@${targetUserID}\>`, allowedMentions: { parse: [], repliedUser: false } });
+        }
+
+    }
+}

--- a/commands/setmsg.js
+++ b/commands/setmsg.js
@@ -1,0 +1,90 @@
+const Discord = require('discord.js');
+const fs = require('fs');
+const { client } = require('../constants.js');
+
+
+module.exports = {
+    name: 'setmsg',
+    description: `Sets a custom built-in Action Message for a specific User`,
+    
+    // Cooldown is in seconds
+    cooldown: 10,
+
+    // Limitation
+    //    - "dev" for TwilightZebby only
+    //    - "owner" for Server Owners and TwilightZebby
+    //    - Comment out for everyone
+    limitation: "dev",
+
+    // Uncomment for making the command only usable in DMs with the Bot
+    //    - DO NOT have both this AND "guildOnly" uncommented, only one or neither
+    //dmOnly: true,
+
+    // Uncomment for making the command only usable in Servers
+    //   - DO NOT have both this AND "dmOnly" uncommented, only one or neither
+    guildOnly: true,
+
+    // Required Arguments?
+    //   - Does the command require arguments? (at least one) Comment out if works without arguments
+    requiresArgs: true,
+    
+    // Argument Checks
+    //   - Minimum required arguments, only use if "requiresArgs" is uncommented
+    minimumArgs: 3,
+    //   - Maximum required arguments, can be used regardless of if "requiresArgs" is commented out or not
+    //maximumArgs: 5,
+
+
+    /**
+     * Entry point that runs the command
+     * 
+     * @param {Discord.Message} message Origin message that triggered this command
+     * @param {Array<String>} args The given arguments of the command. Be sure to check for no arguments!
+     */
+    async execute(message, args) {
+
+        let AUTHORMESSAGES = require('../jsonFiles/authorSpecificMessages.json');
+
+        // Fetch arguments
+        let targetUserID = args.shift();
+        let targetCommandName = args.shift();
+        let customString = args.join(' ');
+        let messagesContruct;
+
+        if ( !AUTHORMESSAGES[`${targetUserID}`] )
+        {
+            // User doesn't have preset custom messages, thus use template
+            messagesContruct = {
+                userNote: `${targetUserID}`,
+                headpat: "**{author}** gave **{receiver}** a headpat",
+                hug: "**{author}** gave **{receiver}** a cuddle",
+                bonk: "**{author}** bonked **{receiver}**",
+                sleep: "**{author}** wants **{receiver}** to go to sleep!",
+                boop: "**{author}** booped **{receiver}**",
+                kiss: "**{author}** kissed **{receiver}**",
+                slap: "**{author}** slapped **{receiver}**"
+            }
+        }
+        else
+        {
+            // User does have preset custom messages already, so pull from them
+            messagesContruct = AUTHORMESSAGES[`${targetUserID}`];
+        }
+
+        messagesContruct[`${targetCommandName}`] = customString;
+        messagesContruct["userNote"] = targetUserID; // Temp put note as ID
+
+        // Store to JSON
+        AUTHORMESSAGES[`${targetUserID}`] = messagesContruct;
+
+        fs.writeFile('./jsonFiles/authorSpecificMessages.json', JSON.stringify(AUTHORMESSAGES, null, 4), async (err) => {
+            if (err)
+            {
+                return await message.reply({ content: `Sorry, but an error occurred while trying to save that custom message...`, allowedMentions: { parse: [], repliedUser: false } });
+            }
+        });
+
+        return await message.reply({ content: `Successfully saved new custom message for User \<\@${targetUserID}\>`, allowedMentions: { parse: [], repliedUser: false } });
+
+    }
+}

--- a/modules/actionModule.js
+++ b/modules/actionModule.js
@@ -54,6 +54,7 @@ module.exports = {
         const EVERYONEMESSAGES = require('../jsonFiles/everyoneMessages.json');
         const SELFMESSAGES = require('../jsonFiles/selfMessages.json');
         const BOTMESSAGES = require('../jsonFiles/botMessages.json');
+        const AUTHORMESSAGES = require('../jsonFiles/authorSpecificMessages.json');
         const CUSTOMMESSAGES = require('../jsonFiles/customMessages.json');
 
         const GIFLINKS = require('../jsonFiles/gifLinks.json');
@@ -101,8 +102,16 @@ module.exports = {
             }
             else
             {
+                // USER MENTION - used *by* a specific User who has a custom set of stored messages
+                if ( AUTHORMESSAGES[`${slashCommand.user.id}`] )
+                {
+                    displayMessage = AUTHORMESSAGES[`${slashCommand.user.id}`][`${slashCommand.commandName}`];
+                }
                 // USER MENTION - used on someone else
-                displayMessage = USERMESSAGES[`${slashCommand.commandName}`];
+                else
+                {
+                    displayMessage = USERMESSAGES[`${slashCommand.commandName}`];
+                }
                 displayMessage = displayMessage.replace(authorRegEx, `${slashCommand.member.displayName}`);
                 displayMessage = displayMessage.replace(receiverRegEx, `${personArgument.displayName}`);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actionsbot",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actionsbot",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "bufferutil": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actionsbot",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "A small bot made by TwilightZebby for Dr1fterX's Discord Server to add Kawaii-Bot style Commands",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- [x] Author specific action messages
- [x] `setmsg` text-based command that allows for dynamic setting of said messages
    - Can only be used by myself, TwilightZebby
    - CMD Syntax: `setmsg <userID> <actionCmdName> <message>`
        - eg: `a!setmsg 156482326887530498 sleep **{author}** ran function sleep( **{receiver}** )`
- [x] `clearmsgs` text-based command that removes custom action messages for a User
    - Can only be used by myself, TwilightZebby
    - CMD Syntax: `clearmsgs <userID>`