### PR TITLE
Rename `/muda` to `/pummel`

### DIFF
--- a/slashCommands/pummel.js
+++ b/slashCommands/pummel.js
@@ -7,7 +7,7 @@ const Action = require('../modules/actionModule.js');
 
 module.exports = {
     // Slash Command's Name, MUST BE LOWERCASE AND NO SPACES
-    name: 'muda',
+    name: 'pummel',
     // Slash Command's description
     description: `Pummel someone with a MUDA MUDA MUDA MUDA MUDAAAAAA!`,
     // Category of Slash Command, used for Help (text) Command


### PR DESCRIPTION
Due to being reminded that the two Stands in JoJo don't both say "muda", one of them says "ora" instead. Since Slash Command Aliases will *never* be a thing, this is second best way of going about that.

In order words, blame Demon on Dr1fterX's Discord ;P